### PR TITLE
Fix FakeObserver call count method

### DIFF
--- a/testingCore/src/main/java/com/yuriisurzhykov/testingcore/FakeObserver.kt
+++ b/testingCore/src/main/java/com/yuriisurzhykov/testingcore/FakeObserver.kt
@@ -15,6 +15,6 @@ interface FakeObserver<T : Any> : Observer<T> {
         }
 
         fun getCurrentValue() = value
-        fun getCallCount() = value
+        fun getCallCount() = callCount
     }
 }


### PR DESCRIPTION
## Summary
- fix `FakeObserver.getCallCount` to return actual call count

## Testing
- `gradle test` *(fails: plugin org.gradle.kotlin.kotlin-dsl not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f45d3114483308fecfcff3c166082